### PR TITLE
Adding customized mapping

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,7 @@
     },
     "uploader": {
         "parser": "parser:load_data",
-        "on_duplicates": "ignore"
+        "on_duplicates": "ignore",
+        "mapping" : "mapping:custom_mapping"
     }
 }

--- a/mapping.py
+++ b/mapping.py
@@ -1,0 +1,77 @@
+def custom_mapping(cls):
+    """
+    Method to provide custom mapping to parser. 
+    
+    Configuration of this method in manifest.json should be: 
+    
+        "uploader" : { 
+            "mapping" : "mapping:custom_mapping"
+        }
+        
+    This is a class method but @classmethod decorator is not necessary. 
+    See https://docs.biothings.io/en/latest/tutorial/studio_guide.html#manifest-based-data-plugins
+    """
+    return {
+        "subject": {
+            "properties": {
+                "id": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                },
+                "name": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                },
+                "ENSEMBL": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                },
+                "type": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                }
+            }
+        },
+        "association": {
+            "properties": {
+                "edge_label": {
+                    "type": "text"
+                }
+            }
+        },
+        "object": {
+            "properties": {
+                "id": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                },
+                "name": {
+                    "type": "text"
+                },
+                "CHEBI": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                },
+                "type": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                },
+                "CHEMBL.COMPOUND": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                },
+                "PUBCHEM": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                },
+                "HMS_LINCS_ID": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                },
+                "CID": {
+                    "normalizer": "keyword_lowercase_normalizer",
+                    "type": "keyword"
+                }
+            }
+        }
+    }


### PR DESCRIPTION
This PR adds a new `mapping` module which is then configured in the manifest.json to provide customized mapping to the API.

To comply with the TRAPI requirements, `association. edge_attributes` field must be a list. However in this API, `association. edge_attributes` field would be a list of heterologous objects and canno be indexed by ES. Therefore customized mapping is needed to prevent this field from being indexed. 